### PR TITLE
trusty for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
 sudo: true
+dist: trusty
 jdk:
   - oraclejdk8


### PR DESCRIPTION
[Travis now updated to Xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) distribution without OracleJDK8. Until project will be ready to migrate to OpenJDK11 I am [explicitly adding Trusty distribution](https://github.com/igniterealtime/Openfire/pull/1425) in builds.

